### PR TITLE
[packaging] Re-enable 'debug' checks in release builds

### DIFF
--- a/rpm/glib2.spec
+++ b/rpm/glib2.spec
@@ -79,10 +79,9 @@ version 2 of the GLib library.
 # << build pre
 %autogen  \
     --enable-static \
-    --with-pcre=system \
-    %{!?qa_stage_devel:--enable-debug=no}
+    --with-pcre=system
 
-make %{?jobs:-j%jobs}
+make %{?_smp_mflags}
 
 # >> build post
 cd tests/gobject


### PR DESCRIPTION
The original intent of using --enable-debug=no on release builds was to
improve stability by removing overly-aggressive asserts and checks that
could bring down important processes. This was misguided: I can't point
to one crash that happens because of an assert/check that wouldn't
otherwise crash, except when G_DEBUG is set in the environment.

Also, many applications implicitly depend on the functionality removed
by G_DISABLE_CHECKS to operate safely. Having that flag in our builds
turns warnings into crashes and could harm stability.

The only valid argument in favor of --enable-debug=no is performance,
but the benefit there is unclear and we don't use glib in
performance-sensitive paths. Other distributions seem to agree, and
don't set this option.

Note that the default is 'minimum', which includes casts, checks, and
asserts. --enable-debug=yes does much more, but it's generally only
enabled for unstable glib versions.
